### PR TITLE
I5: Remove topics not covered during workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,8 +81,6 @@
 <li><a href="06-func.html">Creating Functions</a></li>
 <li><a href="07-errors.html">Errors and Exceptions</a></li>
 <li><a href="08-defensive.html">Defensive Programming</a></li>
-<li><a href="09-debugging.html">Debugging</a></li>
-<li><a href="10-cmdline.html">Command-Line Programs</a></li>
 </ol>
 <h2 id="other-resources">Other Resources</h2>
 <ul>

--- a/index.md
+++ b/index.md
@@ -74,8 +74,6 @@ To do all that, we'll have to learn a little bit about programming.
 6.  [Creating Functions](06-func.html)
 7.  [Errors and Exceptions](07-errors.html)
 8.  [Defensive Programming](08-defensive.html)
-9.  [Debugging](09-debugging.html)
-10.  [Command-Line Programs](10-cmdline.html)
 
 
 ## Other Resources


### PR DESCRIPTION
I simply deleted the links to the topic pages. The topic pages are still in the repo and are still accessible if one knows the URL.

See #5.
